### PR TITLE
Fully automation in the workflow loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## What this project does
-A Python CLI tool that fetches emails from Gmail by label and summarises them using the Claude API (Haiku model). Built as a learning project exploring MCP and agentic AI patterns.
+A Python CLI tool that fetches emails from Gmail and summarises them using the Claude API (Haiku model). Built as a learning project exploring MCP and agentic AI patterns.
 
 ## Commands
 
@@ -30,18 +30,18 @@ Requires a `.env` file with `ANTHROPIC_API_KEY`. Gmail OAuth credentials are sto
 ## Architecture
 
 ### Files
-- `main.py` — entry points for both versions. `v2()` is the active one: collects label + freeform search request from the user, then hands off to `EmailSummaryWorkflow`. `main()` is the V1 flow (kept for reference).
-- `email_summary_workflow.py` — `EmailSummaryWorkflow` class (V2). Runs the agentic loop: sends all MCP tools to Claude Haiku, then iterates `messages.create` → call MCP tool → append result until `stop_reason != "tool_use"`. Saves final summary to `summary.md`.
-- `gmail_mcp_client.py` — `GmailMcpClient` async context manager. Wraps the MCP session lifecycle and exposes: `fetch_labels()`, `search_emails()`, `get_emails()`, `get_email_message()`, `list_tools()`, `use_tool()`.
-- `my_email.py` — `MyEmail` dataclass used in V1. `from_mcp()` parses MCP response; `_clean_body()` strips URLs/footers via regex (~52% token reduction).
+- `main.py` — entry point. `v2()` prompts for a freeform search request and hands off to `EmailSummaryWorkflow`.
+- `email_summary_workflow.py` — `EmailSummaryWorkflow` class. Runs the agentic loop: sends all MCP tools to Claude Haiku, handles `tool_use` (parallel) and `stop_sequence` (`[DONE]`/`[QUESTION]`) responses. `_prepare_messages_for_api()` strips `get_emails` bodies from history before each API call to reduce tokens. Saves final summary to `summary.md`.
+- `gmail_mcp_client.py` — `GmailMcpClient` async context manager. Wraps the MCP session lifecycle; exposes `list_tools()` and `use_tool()`. Also has `fetch_labels()` (parses `Name:` lines from `list_available_labels`) but it is not currently called.
 - `run_gmail_mcp_server.py` — one-liner that starts the `mcp-gmail` server as a subprocess (via `StdioServerParameters`).
 
 ### V2 agentic flow
-1. `GmailMcpClient` opens MCP session → `fetch_labels()` → `prompt_toolkit` autocomplete for label selection
-2. User types a freeform search request (e.g. "last 5 unread emails")
-3. `EmailSummaryWorkflow.start()` builds the system prompt (injects today's date, label, and request), fetches all available MCP tools via `list_tools()`, then enters the tool-use loop
-4. Loop: `messages.create` → if `stop_reason == "tool_use"`, call the MCP tool, append assistant + tool_result messages, repeat
-5. Final text response is printed and written to `summary.md`
+1. User types a freeform search request (e.g. "last 5 unread emails")
+2. `EmailSummaryWorkflow.start()` builds the system prompt (injects today's date and search request), fetches all MCP tools via `list_tools()`, enters the loop
+3. Loop: `_prepare_messages_for_api()` strips email bodies from history → `messages.create` with `stop_sequences=["[DONE]", "[QUESTION]"]`
+4. On `tool_use`: execute all tool_use blocks in parallel, append results tagged with `_tool_name` for later pruning, continue
+5. On `[QUESTION]` stop sequence: append assistant message, collect user input, continue
+6. On `[DONE]` stop sequence: break, write final response to `summary.md`
 
 ### MCP tool names (as registered on the server)
 Full list: `compose_email`, `send_email`, `search_emails`, `query_emails`, `list_available_labels`, `mark_message_read`, `add_label_to_message`, `remove_label_from_message`, `get_emails`
@@ -60,9 +60,10 @@ Resource templates (not tools, used in V1): accessible via `session.read_resourc
 
 ## Key technical decisions
 - `asyncio` + MCP Python SDK (`mcp` v1.27.0) for Gmail calls — avoids routing through Anthropic
-- `PromptSession.prompt_async()` required (not `prompt()`) — running inside an async event loop
 - MCP session kept open for entire run via `GmailMcpClient` async context manager
-- In V2, `EmailSummaryWorkflow` passes all MCP tools to Claude as-is (no filtering); Claude selects which to call
-- Tool result content accessed via `result.content[0].text`; email bodies must be cleared from the messages list before re-sending to Claude to reduce token usage (known TODO as of last commit)
+- All MCP tools passed to Claude as-is (no filtering); Claude selects which to call
+- Tool result content accessed via `result.content[0].text`
+- `_tool_name` is a private field tagged onto tool result dicts (not sent to API); `_prepare_messages_for_api()` uses it to identify and strip `get_emails` bodies before each API call
+- Stop sequences `[DONE]` and `[QUESTION]` are used instead of relying on `stop_reason == "end_turn"` — gives Claude a structured way to signal completion or request user input mid-run
 - Do NOT name any file `email.py` — shadows Python's built-in `email` module and breaks `mcp-gmail`
 - `gmail_url` constructed as `https://mail.google.com/mail/u/0/#inbox/{message_id}` from the message ID

--- a/README.md
+++ b/README.md
@@ -7,18 +7,17 @@ It's also a learning project — specifically an exploration of the Model Contex
 
 ## How it works
 
-1. Fetches your Gmail labels via the Gmail MCP server and prompts you to pick one using an autocomplete dropdown
-2. Accepts a freeform natural language search request (e.g. *"last 5 unread emails"*, *"emails about MCP from last Friday"*)
-3. Hands the request to Claude Haiku, which drives the Gmail tool calls directly — searching and fetching emails autonomously
-4. Prints the summary to the terminal and saves it to `summary.md`
+1. Accepts a freeform natural language search request (e.g. *"last 5 unread emails"*, *"emails about MCP from last Friday"*)
+2. Hands the request to Claude Haiku, which drives the Gmail tool calls directly — searching for matching emails and confirming with you before fetching
+3. Prints the summary to the terminal and saves it to `summary.md`
 
 ## Architecture
 
 The app has three main components:
 
-- **`gmail_mcp_client.py`** — async context manager wrapping the MCP `ClientSession`. Handles the MCP session lifecycle and exposes `fetch_labels()`, `list_tools()`, and `use_tool()` for direct tool dispatch
-- **`email_summary_workflow.py`** — drives the agentic loop: sends all available Gmail MCP tools to Claude Haiku, then iterates tool call → MCP execution → result append until Claude produces a final text summary
-- **`main.py`** — entry point. Handles label selection with autocomplete, collects the freeform search request, and starts the workflow
+- **`gmail_mcp_client.py`** — async context manager wrapping the MCP `ClientSession`. Handles the MCP session lifecycle and exposes `list_tools()` and `use_tool()` for direct tool dispatch
+- **`email_summary_workflow.py`** — drives the agentic loop: sends all available Gmail MCP tools to Claude Haiku, handles tool calls, and uses stop sequences (`[DONE]`, `[QUESTION]`) to manage completion and mid-run user confirmations
+- **`main.py`** — entry point. Collects the freeform search request and starts the workflow
 
 This is a V2 implementation where Claude drives the Gmail tool calls directly via the Anthropic tools API. Python handles only the initial user input and session lifecycle.
 
@@ -125,15 +124,13 @@ python main.py
 
 You will be prompted for:
 
-- **Gmail label** — autocomplete dropdown populated from your account, e.g. `Data Science`
 - **Search request** — freeform natural language, e.g. `last 5 unread emails` or `emails about Python from this week`
 
-Claude will search and fetch the matching emails autonomously, then print a summary to the terminal and save it to `summary.md`.
+Claude will search for matching emails, confirm with you before fetching, then print a summary to the terminal and save it to `summary.md`.
 
 ## Known limitations
 
 - No retry logic if the Gmail MCP server or Claude API call fails
-- Email bodies are included in the full message history sent back to Claude on each tool loop iteration — this increases token usage for longer runs
 
 ## Roadmap
 
@@ -144,5 +141,4 @@ Claude will search and fetch the matching emails autonomously, then print a summ
 **Future improvements:**
 - Prompt engineering to make summary output more consistent and structured
 - Ability to email the summary directly and make the search interaction more conversational
-- Token optimisation — clear email bodies from the message history before re-sending to Claude to reduce cost
 - A better UI (web or desktop) to replace the terminal prompt

--- a/email_summary_workflow.py
+++ b/email_summary_workflow.py
@@ -9,7 +9,6 @@ class EmailSummaryWorkflow:
 
     
     def __init__(self, search_request, client):
-        #self.email_label = email_label
         self.user_search_request = search_request
         self.mcp_client = client
 
@@ -80,7 +79,7 @@ class EmailSummaryWorkflow:
             - format as Markdown
             - for each email:
                 - provide a header with format 
-                    Subject - (Sender)[https://mail.google.com/mail/u/0/#inbox/message_id]
+                    Subject - [Sender](https://mail.google.com/mail/u/0/#inbox/message_id)
                 - provide a summary of the topics with each topic as a bullet points
             - at the end summarise the main trends across the emails retrieved
             """
@@ -93,9 +92,6 @@ class EmailSummaryWorkflow:
         messages.append(user_message)
         
         mcp_tools = await self.mcp_client.list_tools()
-
-        #print(type(mcp_tools))
-        #print(mcp_tools)
 
         tools = [
             {
@@ -124,6 +120,7 @@ class EmailSummaryWorkflow:
                 if response.stop_sequence == "[DONE]":
                     break
                 if response.stop_sequence == "[QUESTION]":
+                    messages.append({"role": "assistant", "content": response.content}) 
                     user_input = input(">")
                     messages.append({"role": "user", "content": user_input})
                     continue

--- a/email_summary_workflow.py
+++ b/email_summary_workflow.py
@@ -8,8 +8,8 @@ load_dotenv()
 class EmailSummaryWorkflow:
 
     
-    def __init__(self, email_label, search_request, client):
-        self.email_label = email_label
+    def __init__(self, search_request, client):
+        #self.email_label = email_label
         self.user_search_request = search_request
         self.mcp_client = client
 
@@ -18,29 +18,72 @@ class EmailSummaryWorkflow:
         )
         self.antropic_client = client
 
-    def tool_data(self, claude_response):
-        for block in claude_response.content:
-            if block.type == "tool_use":
-                return block.name, block.input, block.id
+    def _prepare_messages_for_api(self, messages):
+        cleaned = []
+        for message in messages:
+            if message["role"] == "user" and isinstance(message["content"], list):
+                cleaned_blocks = []
+                for block in message["content"]:
+                    if isinstance(block, dict) and block.get("type") == "tool_result":
+                        clean_block = {
+                            "type": "tool_result",
+                            "tool_use_id": block["tool_use_id"],
+                            "content": (
+                                "[email bodies removed from history]"
+                                if block.get("_tool_name") == "get_emails"
+                                else block["content"]
+                            )
+                        }
+                        cleaned_blocks.append(clean_block)
+                    else:
+                        cleaned_blocks.append(block)
+                cleaned.append({**message, "content": cleaned_blocks})
+            else:
+                cleaned.append(message)
+        return cleaned
 
     async def start(self):
         messages = []
         today = datetime.today().strftime("%Y/%m/%d")
-        first_message=f"""
+        first_message = f"""
             You are an email summarisation assistant. Your only task is to fetch and summarise emails from Gmail using the available tools.
-            You will be given a Gmail label and a search criteria from the user. Use the Gmail tools to fetch the emails matching those criteria and summarise them.
-            Today's date is {today}. If no date range is specified, you must default to only search emails received in the last 3 days.
-            Regardless of how many emails are found, you must cap the total number of emails to summarise to a maximum of 10.
-            If the user asks anything unrelated to fetching and summarising emails, respond with a plain text message explaining you can only help with email summarisation and do not call any tools.
-            
-            <gmail_label>
-            {self.email_label}
-            </gmail_label>
 
-            <user_search_crieria>
+            Today's date is {today}.
+
+            ## Rules
+
+            1. Use the Gmail tools to fetch emails matching the user's search request and summarise them.
+            2. If no date range is specified, default to emails received in the last 3 days.
+            3. Cap the total number of emails to summarise to a maximum of 10.
+            4. If the user asks anything unrelated to fetching and summarising emails, explain you can only help with email summarisation and do not call any tools.
+            5. When searching for emails received on a specific day, set after_date to that day and before_date to the following day.
+            
+            ## Mandatory output rules — follow these without exception
+
+            - Any time you want to ask the user something or need their input — including confirmations, clarifications, or corrections — you MUST output [QUESTION] immediately after your question. No exceptions.
+            - You MUST NOT end a turn with a question unless you have output [QUESTION] first.
+            - Once you have delivered the final summary and have no further questions, you MUST output [DONE] on its own line. Do not output [DONE] at any other point.
+
+            ## Workflow
+
+            1. Search for emails matching the user's request using the available tools.
+            2. After identifying the matching emails, always summarise what you found and confirm with the user how to proceed before doing anything further. Output [QUESTION] after this confirmation request.
+            3. Once confirmed, fetch the emails and produce the summary.
+            4. Output [DONE] after the summary.
+
+
+            <search_request>
             {self.user_search_request}
-            </user_search_crieria>
-        """
+            </search_request>
+
+            ## Email summary result
+            - format as Markdown
+            - for each email:
+                - provide a header with format 
+                    Subject - (Sender)[https://mail.google.com/mail/u/0/#inbox/message_id]
+                - provide a summary of the topics with each topic as a bullet points
+            - at the end summarise the main trends across the emails retrieved
+            """
 
         user_message = {
             "role":"user",
@@ -48,7 +91,7 @@ class EmailSummaryWorkflow:
         }
 
         messages.append(user_message)
-
+        
         mcp_tools = await self.mcp_client.list_tools()
 
         #print(type(mcp_tools))
@@ -63,44 +106,48 @@ class EmailSummaryWorkflow:
             for tool in mcp_tools.tools
         ]
 
-        message = None
+        response = None
 
         while True:
-
-            message = self.antropic_client.messages.create(
+            response = self.antropic_client.messages.create(
                 max_tokens=4096,
-                messages=messages,
+                messages=self._prepare_messages_for_api(messages),
                 tools = tools,
+                stop_sequences=["[DONE]", "[QUESTION]"],
                 model="claude-haiku-4-5-20251001",
             )
 
-            if message.stop_reason != "tool_use":
+            if response.content[0].type == "text":
+                print(response.content[0].text)
+
+            if response.stop_reason == "stop_sequence":
+                if response.stop_sequence == "[DONE]":
+                    break
+                if response.stop_sequence == "[QUESTION]":
+                    user_input = input(">")
+                    messages.append({"role": "user", "content": user_input})
+                    continue
+            elif response.stop_reason == "tool_use":
+                tool_use_blocks = [block for block in response.content if block.type == "tool_use"]
+
+                tool_results = []
+                for block in tool_use_blocks:
+                    result = await self.mcp_client.use_tool(block.name, block.input)
+                    tool_results.append({
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": result.content[0].text,
+                        "_tool_name": block.name  # private tag for pruning
+                    })
+
+                messages.append({"role": "assistant", "content": response.content})
+                messages.append({"role": "user", "content": tool_results})
+                continue
+            else:
                 break
 
-            if message.content[0].type == "text":
-                print(message.content[0].text)
-
-            tool_name, tool_input, tool_use_id= self.tool_data(message)
-
-            result = await self.mcp_client.use_tool(tool_name, tool_input)
-
-            messages.append({"role": "assistant", "content": message.content})
-
-            messages.append({
-                "role":"user",
-                "content": [
-                    {
-                        "type":"tool_result",
-                        "tool_use_id":tool_use_id,
-                        "content":result.content[0].text
-                    }
-                ]
-            })
-
-        if message:
-            print(message.content[0].text)
-
-        with open('summary.md', 'w') as f:
-            f.write(message.content[0].text)
+        if response:
+            with open('summary.md', 'w') as f:
+                f.write(response.content[0].text)
 
 

--- a/main.py
+++ b/main.py
@@ -1,8 +1,5 @@
 import asyncio
-from dotenv import load_dotenv
 from gmail_mcp_client import GmailMcpClient
-from prompt_toolkit.completion import WordCompleter
-from prompt_toolkit import PromptSession
 from email_summary_workflow import EmailSummaryWorkflow
 
 async def v2():
@@ -11,8 +8,6 @@ async def v2():
 
         workflow = EmailSummaryWorkflow(search_request, client)
         await workflow.start()
-
-
 
 if __name__ == "__main__":
     asyncio.run(v2())

--- a/main.py
+++ b/main.py
@@ -7,23 +7,9 @@ from email_summary_workflow import EmailSummaryWorkflow
 
 async def v2():
     async with GmailMcpClient() as client:
-        # no worth having Claude to trigger this call
-        labels = await client.fetch_labels()
-        label_completer = WordCompleter(labels, ignore_case=True)
-        session_pt = PromptSession()
-        label = await session_pt.prompt_async("Select Gmail label: ", completer=label_completer)
-        print(f"We will summarise only emails with label '{label}'")
-        print(f"""
-        Now tell Claude which emails you want to summarise. For example:
-              `All the emails in the last 7 days`
-              `3 emails from last Friday`
-              `emails with "MCP" in the subject`
-              `Last 7 unread emails`
-        If a date range is not specified we will consider emails in the last 3 days.
-              """)
-        search_request=input(">")
+        search_request=input("Tell Claude which emails you want to summarise :>")
 
-        workflow = EmailSummaryWorkflow(label, search_request, client)
+        workflow = EmailSummaryWorkflow(search_request, client)
         await workflow.start()
 
 


### PR DESCRIPTION
- Changed `EmailSummaryWorkflow` to better handle interactions with the user, this means the user can ask more contextual questions before deciding on search criteria.  For example the user can ask how many emails were unread yesterday, or which kind of labels they have in their Gmail.  The main change is in the workflow loop where we handle different type of stop_reason and stop_sequence to decide whether to get a new input from the user, call tools, or just stop the chat
- Changed the prompt to clarify rules of the task, mandatory steps, workflow, and format for the summary
- Added a pruning step to remove the emails bodies from user messages containing a tool_result, we don't need to keep the body of the emails except for summarisation (after which the process will stop anyway) and this allow us to significantly reduce the number of tokens from nearly 95k to around 4k

<img width="1174" height="364" alt="Screenshot_2026-04-06_at_16_34_58" src="https://github.com/user-attachments/assets/2b4fe05f-3d59-4065-ba9d-0d535104a3ec" />